### PR TITLE
cleanup widget, fix markers under cordova, fix running multiple versions

### DIFF
--- a/src/GoogleMaps/lib/async.js
+++ b/src/GoogleMaps/lib/async.js
@@ -1,0 +1,44 @@
+/** @license
+ * RequireJS plugin for async dependency load like JSONP and Google Maps
+ * Author: Miller Medeiros
+ * Version: 0.1.2 (2014/02/24)
+ * Released under the MIT license
+ */
+define(function(){
+
+    var DEFAULT_PARAM_NAME = 'callback',
+        _uid = 0;
+
+    function injectScript(src){
+        var s, t;
+        s = document.createElement('script'); s.type = 'text/javascript'; s.async = true; s.src = src;
+        t = document.getElementsByTagName('script')[0]; t.parentNode.insertBefore(s,t);
+    }
+
+    function formatUrl(name, id){
+        var paramRegex = /!(.+)/,
+            url = name.replace(paramRegex, ''),
+            param = (paramRegex.test(name))? name.replace(/.+!/, '') : DEFAULT_PARAM_NAME;
+        url += (url.indexOf('?') < 0)? '?' : '&';
+        return url + param +'='+ id;
+    }
+
+    function uid() {
+        _uid += 1;
+        return '__async_req_'+ _uid +'__';
+    }
+
+    return{
+        load : function(name, req, onLoad, config){
+            if(config.isBuild){
+                onLoad(null); //avoid errors on the optimizer
+            }else{
+                var id = uid();
+                //create a global variable that stores onLoad so callback
+                //function can define new module after async load
+                window[id] = onLoad;
+                injectScript(formatUrl(req.toUrl(name), id));
+            }
+        }
+    };
+});

--- a/src/GoogleMaps/lib/googlemaps.js
+++ b/src/GoogleMaps/lib/googlemaps.js
@@ -1,0 +1,159 @@
+define([
+  'GoogleMaps/lib/async'
+], function(async) {
+  var root = this;
+
+  /**
+   * Google maps AMD loader plugin.
+   *
+   * Example:
+   *  // All configs options are optional.
+   *  require.config({
+   *      googlemaps: {
+   *        url: 'https://maps.googleapis.com/maps/api/js',
+   *        params: {
+   *          key: 'abcd1234',
+   *          libraries: 'geometry',
+   *          sensor: true                // Defaults to false
+   *        },
+   *        async: asyncLoaderPlugin      // Primarly for providing test stubs.
+   *      }
+   *  });
+   *
+   *  require(['googlemaps!'], function(gmaps) {
+   *    var map = new gmaps.Map('map-canvas);
+   *  });
+   *
+   */
+  var googlemapsPlugin = {
+    load: function(name, parentRequire, onload, opt_config) {
+      var googleMapsLoader;
+      var config = opt_config || {};
+
+      if (config.isBuild) {
+        onload(null);
+        return;
+      }
+
+      googleMapsLoader = new GoogleMapsLoader(parentRequire, onload, config.googlemaps || {});
+      googleMapsLoader.load();
+    }
+  };
+
+
+  /**
+   * Helper class for googlemaps loader plugin.
+   */
+  var GoogleMapsLoader = function(require, onload, config) {
+    this.require_ = require;
+    this.onload_ = onload || NOOP;
+    this.baseUrl_ = config.url || GoogleMapsLoader.DEFAULT_BASE_URL;
+    this.async_ = config.async || async;
+    this.params_ = this.normalizeParams_(config.params);
+  };
+
+
+  GoogleMapsLoader.prototype.load = function() {
+    if (this.isGoogleMapsLoaded_()) {
+      this.resolveWith_(this.getGlobalGoogleMaps_());
+    }
+    else {
+      this.loadGoogleMaps_();
+    }
+  };
+
+
+  GoogleMapsLoader.prototype.loadGoogleMaps_ = function() {
+    var self = this;
+
+    var onAsyncLoad = function() {
+      // Ensure correct context
+      self.resolveWithGoogleMaps_(self);
+    };
+    onAsyncLoad.onerror = this.onload_.onerror;
+
+    this.async_.load(this.getGoogleUrl_(), this.require_, onAsyncLoad, {});
+  };
+
+
+  GoogleMapsLoader.prototype.getGoogleUrl_ = function() {
+    return this.baseUrl_ + '?' + this.serializeParams_();
+  };
+
+
+  GoogleMapsLoader.prototype.resolveWithGoogleMaps_ = function() {
+    if (!this.isGoogleMapsLoaded_()) {
+      this.reject_();
+      return;
+    }
+
+    this.resolveWith_(this.getGlobalGoogleMaps_());
+  };
+
+
+  /** Thanks to http://jsfiddle.net/rudiedirkx/U5Tyb/1/ */
+  GoogleMapsLoader.prototype.serializeParams_ = function() {
+    var encodedParams = [];
+    for (var key in this.params_) {
+      if (this.params_.hasOwnProperty(key)) {
+        var value = this.params_[key];
+        var isObject = (typeof value === 'object');
+        var encodedParam = encodeURIComponent(key) + "=" + encodeURIComponent(value);
+        var serializedValue = isObject ? this.serializeParams_(value, key) : encodedParam;
+
+        encodedParams.push(serializedValue);
+      }
+    }
+
+    return encodedParams.join("&");
+  };
+
+
+  GoogleMapsLoader.prototype.normalizeParams_ = function(params) {
+    var defaultParams = {
+      sensor: false
+    };
+    params || (params = {});
+
+    params.sensor = (params.sensor == void 0) ? defaultParams.sensor : params.sensor;
+
+    return params;
+  };
+
+
+  GoogleMapsLoader.prototype.isGoogleMapsLoaded_ = function() {
+    return root.google && root.google.maps;
+  };
+
+
+  GoogleMapsLoader.prototype.getGlobalGoogleMaps_ = function() {
+    return root.google ? root.google.maps : undefined;
+  };
+
+
+  GoogleMapsLoader.prototype.resolveWith_ = function(var_args) {
+    this.onload_.apply(root, arguments);
+  };
+
+
+  GoogleMapsLoader.prototype.reject_ = function(opt_error) {
+    var error = opt_error || new Error('Failed to load Google Maps library.');
+
+    if (this.onload_.onerror) {
+      this.onload_.onerror.call(root, error);
+    }
+    else {
+      throw error;
+    }
+  };
+
+
+  GoogleMapsLoader.DEFAULT_BASE_URL = 'https://maps.googleapis.com/maps/api/js';
+
+
+  function NOOP() {
+  }
+
+
+  return googlemapsPlugin;
+});

--- a/src/GoogleMaps/widget/GoogleMaps.js
+++ b/src/GoogleMaps/widget/GoogleMaps.js
@@ -24,7 +24,7 @@ define([
                 this._loadMap();
             });
 
-            this._loadGoogle();
+            this._loadMap();
         },
 
         update: function (obj, callback) {
@@ -65,11 +65,6 @@ define([
                     })
                 });
             }
-        },
-
-        _loadGoogle: function () {
-            console.log(this.id + '_loadGoogle');
-	    this._loadMap();
         },
 
         _loadMap: function () {

--- a/src/GoogleMaps/widget/GoogleMaps.js
+++ b/src/GoogleMaps/widget/GoogleMaps.js
@@ -1,38 +1,16 @@
 /*jslint white:true, nomen: true, plusplus: true */
 /*global mx, define, require, browser, devel, console, google, window */
-/*mendix */
-/*
-    GoogleMaps
-    ========================
 
-    @file      : GoogleMaps.js
-    @version   : 4.0
-    @author    : Pauline Oudeman
-    @date      : Mon, 09 Mar 2015 07:44:24 GMT
-    @copyright : 
-    @license   : 
-
-    Documentation
-    ========================
-    Describe your widget here.
-*/
-
-// Required module list. Remove unnecessary modules, you can always get them back from the boilerplate.
-require([
+define([
     'dojo/_base/declare', 'mxui/widget/_WidgetBase', 'dijit/_TemplatedMixin',
-    'mxui/dom', 'dojo/dom', 'dojo/query', 'dojo/dom-prop', 'dojo/dom-geometry', 'dojo/dom-class', 'dojo/dom-style', 'dojo/dom-construct', 'dojo/_base/array', 'dojo/_base/lang', 'dojo/text',
+    'dojo/dom-style', 'dojo/dom-construct', 'dojo/_base/array', 'dojo/_base/lang',
     'dojo/text!GoogleMaps/widget/template/GoogleMaps.html'
-], function (declare, _WidgetBase, _TemplatedMixin, dom, dojoDom, domQuery, domProp, domGeom, domClass, domStyle, domConstruct, dojoArray, lang, text, widgetTemplate) {
+], function (declare, _WidgetBase, _TemplatedMixin, domStyle, domConstruct, dojoArray, lang, widgetTemplate) {
     'use strict';
 
-    // Declare widget's prototype.
     return declare('GoogleMaps.widget.GoogleMaps', [_WidgetBase, _TemplatedMixin], {
-        // _TemplatedMixin will create our dom node using this HTML template.
         templateString: widgetTemplate,
 
-        // Parameters configured in the Modeler.
-
-        // Internal variables. Non-primitives created in the prototype are shared between all widget instances.
         _handle: null,
         _contextObj: null,
         _googleMap: null,
@@ -40,10 +18,6 @@ require([
         _googleScript: null,
 
 
-        // dojo.declare.constructor is called to construct the widget instance. Implement to initialize non-primitive properties.
-        constructor: function () {},
-
-        // dijit._WidgetBase.postCreate is called after constructing the widget. Implement to do extra setup work.
         postCreate: function () {
             console.log(this.id + '.postCreate');
             window[this.id + "_mapsCallback"] = lang.hitch(this, function () {
@@ -54,12 +28,10 @@ require([
             this._setupEvents();
         },
 
-        // mxui.widget._WidgetBase.update is called when context is changed or initialized. Implement to re-render and / or fetch data.
         update: function (obj, callback) {
             console.log(this.id + '.update');
             this._contextObj = obj;
 
-            //subscribe to changes
             this._resetSubscriptions();
             if (this._googleMap) {
                 this._fetchMarkers();
@@ -68,17 +40,6 @@ require([
             callback();
         },
 
-        // mxui.widget._WidgetBase.enable is called when the widget should enable editing. Implement to enable editing if widget is input widget.
-        enable: function () {
-
-        },
-
-        // mxui.widget._WidgetBase.enable is called when the widget should disable editing. Implement to disable editing if widget is input widget.
-        disable: function () {
-
-        },
-
-        // mxui.widget._WidgetBase.resize is called when the page's layout is recalculated. Implement to do sizing calculations. Prefer using CSS instead.
         resize: function (box) {
             console.log(this.id + '_resize');
             if (this._googleMap) {
@@ -86,23 +47,12 @@ require([
             }
         },
 
-        // mxui.widget._WidgetBase.uninitialize is called when the widget is destroyed. Implement to do special tear-down work.
         uninitialize: function () {
-            // Clean up listeners, helper objects, etc. There is no need to remove listeners added with this.connect / this.subscribe / this.own.
             window[this.id + "_mapsCallback"] = null;
-
         },
 
-
-        //Events
-        _setupEvents: function () {
-
-        },
-
-        //Subscriptions
         _resetSubscriptions: function () {
             console.log(this.id + '_resetSubscriptions');
-            // Release handle on previous object, if any.
             if (this._handle) {
                 this.unsubscribe(this._handle);
                 this._handle = null;
@@ -118,8 +68,6 @@ require([
             }
         },
 
-
-        //start Google and create the map
         _loadGoogle: function () {
             console.log(this.id + '_loadGoogle');
             if (!window.google) {
@@ -132,7 +80,6 @@ require([
             }
         },
 
-        //load the map
         _loadMap: function () {
             console.log(this.id + '_loadMap');
             domStyle.set(this.mapContainer, {
@@ -153,7 +100,6 @@ require([
 
         },
 
-        //Fetch markers
         _fetchMarkers: function () {
             console.log(this.id + '_fetchMarkers');
 
@@ -177,7 +123,6 @@ require([
         _fetchFromDB: function () {
             console.log(this.id + '_fetchFromDB');
             var xpath = '//' + this.mapEntity + this.xpathConstraint,
-                //extract this function because we use it twice
                 cb = function (objs) {
                     var self = this,
                         bounds = new google.maps.LatLngBounds();
@@ -228,7 +173,7 @@ require([
                     self._googleMap.fitBounds(bounds);
                 }
             });
-            //fetch from the database if not already cached.
+
             if (!cached) {
                 console.log('not cached yet');
                 this._fetchFromDB();
@@ -245,10 +190,8 @@ require([
             }
         },
 
-        //Add markers to the map
         _addMarker: function (obj) {
             console.log(this.id + '_addMarker');
-            //Create a new google marker
             var id = this._contextObj ? this._contextObj.getGuid() : null,
                 marker = new google.maps.Marker({
                     position: new google.maps.LatLng(obj.get(this.latAttr), obj.get(this.lngAttr)),
@@ -258,17 +201,14 @@ require([
                 markerImageURL = null,
                 url = null;
 
-            //set id if available
             if (id) {
                 marker.id = id;
             }
 
-            //Set a title, if available
             if (this.markerDisplayAttr) {
                 marker.setTitle(obj.get(this.markerDisplayAttr));
             }
 
-            //Set marker image if available
             if (this.markerImages.length > 1) {
                 dojoArray.forEach(this.markerImages, function (imageObj) {
                     if (imageObj.enumKey === obj.get(self.enumAttr)) {
@@ -279,12 +219,10 @@ require([
                 markerImageURL = this.defaultIcon;
             }
             
-            //set marker image
             if (markerImageURL) {
                 marker.setIcon(window.mx.appUrl + markerImageURL);
             }
 
-            //build cache
             if (!this._markerCache) {
                 this._markerCache = [];
             }
@@ -304,3 +242,5 @@ require([
         }
     });
 });
+
+require(["GoogleMaps/widget/GoogleMaps"], function() {});

--- a/src/GoogleMaps/widget/GoogleMaps.js
+++ b/src/GoogleMaps/widget/GoogleMaps.js
@@ -281,7 +281,7 @@ require([
             
             //set marker image
             if (markerImageURL) {
-                marker.setIcon(markerImageURL);
+                marker.setIcon(window.mx.appUrl + markerImageURL);
             }
 
             //build cache

--- a/src/GoogleMaps/widget/GoogleMaps.js
+++ b/src/GoogleMaps/widget/GoogleMaps.js
@@ -19,7 +19,6 @@ define([
 
 
         postCreate: function () {
-            console.log(this.id + '.postCreate');
             window[this.id + "_mapsCallback"] = lang.hitch(this, function () {
                 this._loadMap();
             });
@@ -28,7 +27,6 @@ define([
         },
 
         update: function (obj, callback) {
-            console.log(this.id + '.update');
             this._contextObj = obj;
 
             this._resetSubscriptions();
@@ -40,7 +38,6 @@ define([
         },
 
         resize: function (box) {
-            console.log(this.id + '_resize');
             if (this._googleMap) {
                 google.maps.event.trigger(this._googleMap, 'resize');
             }
@@ -51,7 +48,6 @@ define([
         },
 
         _resetSubscriptions: function () {
-            console.log(this.id + '_resetSubscriptions');
             if (this._handle) {
                 this.unsubscribe(this._handle);
                 this._handle = null;
@@ -68,7 +64,6 @@ define([
         },
 
         _loadMap: function () {
-            console.log(this.id + '_loadMap');
             domStyle.set(this.mapContainer, {
                 height: this.mapHeight + 'px',
                 width: this.mapWidth
@@ -88,8 +83,6 @@ define([
         },
 
         _fetchMarkers: function () {
-            console.log(this.id + '_fetchMarkers');
-
             if (this.gotocontext) {
                 this._goToContext();
             } else {
@@ -108,7 +101,6 @@ define([
         },
 
         _fetchFromDB: function () {
-            console.log(this.id + '_fetchFromDB');
             var xpath = '//' + this.mapEntity + this.xpathConstraint,
                 cb = function (objs) {
                     var self = this,
@@ -139,7 +131,6 @@ define([
         },
 
         _fetchFromCache: function () {
-            console.log(this.id + '_fetchFromCache');
             var self = this,
                 cached = false,
                 bounds = new google.maps.LatLngBounds();
@@ -162,14 +153,12 @@ define([
             });
 
             if (!cached) {
-                console.log('not cached yet');
                 this._fetchFromDB();
             }
 
         },
 
         _removeAllMarkers: function () {
-            console.log(this.id + '_removeAllMarkers');
             if (this._markerCache) {
                 dojoArray.forEach(this._markerCache, function (marker) {
                     marker.setMap(null);
@@ -178,7 +167,6 @@ define([
         },
 
         _addMarker: function (obj) {
-            console.log(this.id + '_addMarker');
             var id = this._contextObj ? this._contextObj.getGuid() : null,
                 marker = new google.maps.Marker({
                     position: new google.maps.LatLng(obj.get(this.latAttr), obj.get(this.lngAttr)),
@@ -205,7 +193,7 @@ define([
             } else if(this.defaultIcon) {
                 markerImageURL = this.defaultIcon;
             }
-            
+
             if (markerImageURL) {
                 marker.setIcon(window.mx.appUrl + markerImageURL);
             }
@@ -219,7 +207,6 @@ define([
         },
 
         _goToContext: function () {
-            console.log(this.id + '_goToContext');
             this._removeAllMarkers();
             if (this._googleMap && this._contextObj) {
                 this._googleMap.setZoom(this.lowestZoom);

--- a/src/GoogleMaps/widget/GoogleMaps.js
+++ b/src/GoogleMaps/widget/GoogleMaps.js
@@ -4,8 +4,8 @@
 define([
     'dojo/_base/declare', 'mxui/widget/_WidgetBase', 'dijit/_TemplatedMixin',
     'dojo/dom-style', 'dojo/dom-construct', 'dojo/_base/array', 'dojo/_base/lang',
-    'dojo/text!GoogleMaps/widget/template/GoogleMaps.html'
-], function (declare, _WidgetBase, _TemplatedMixin, domStyle, domConstruct, dojoArray, lang, widgetTemplate) {
+    'GoogleMaps/lib/googlemaps!', 'dojo/text!GoogleMaps/widget/template/GoogleMaps.html'
+], function (declare, _WidgetBase, _TemplatedMixin, domStyle, domConstruct, dojoArray, lang, googleMaps, widgetTemplate) {
     'use strict';
 
     return declare('GoogleMaps.widget.GoogleMaps', [_WidgetBase, _TemplatedMixin], {
@@ -25,7 +25,6 @@ define([
             });
 
             this._loadGoogle();
-            this._setupEvents();
         },
 
         update: function (obj, callback) {
@@ -70,14 +69,7 @@ define([
 
         _loadGoogle: function () {
             console.log(this.id + '_loadGoogle');
-            if (!window.google) {
-                this._googleScript = dom.create('script');
-                this._googleScript.type = 'text/javascript';
-                this._googleScript.src = 'https://maps.googleapis.com/maps/api/js?v=3&callback=' + this.id + '_mapsCallback';
-                domConstruct.place(this._googleScript, this.domNode);
-            } else {
-                this._loadMap();
-            }
+	    this._loadMap();
         },
 
         _loadMap: function () {


### PR DESCRIPTION
When running in a hybrid/cordova environment, your baseurl is a file on
disk, so we need to use absolute URLs when loading icons to use as
markers.
