### PR TITLE
Refresh on entity if no context provided

### DIFF
--- a/src/GoogleMaps/widget/GoogleMaps.js
+++ b/src/GoogleMaps/widget/GoogleMaps.js
@@ -62,6 +62,15 @@ define([
                     })
                 });
             }
+            else {
+                this._handle = this.subscribe({
+                    entity: this.mapEntity,
+                    callback: lang.hitch(this, function (entity) {
+                        this._fetchMarkers();
+                    })
+                });
+
+            }
         },
 
         _loadMap: function () {


### PR DESCRIPTION
Old widget apparently always worked from a dataview and listened to that
object, so it was logical to only listen to one obj. Current widget
assumes xpaths more than context, so it makes more sense to listen to an
entity (at least when no context is available).
