### PR TITLE
Redraw google maps widget on update

### DIFF
--- a/src/GoogleMaps/widget/GoogleMaps.js
+++ b/src/GoogleMaps/widget/GoogleMaps.js
@@ -33,6 +33,7 @@ define([
             this._resetSubscriptions();
             if (this._googleMap) {
                 this._fetchMarkers();
+                google.maps.event.trigger(this._googleMap, 'resize');
             }
 
             callback();


### PR DESCRIPTION
In some instances, this widget doesn't render correctly when shown in a
popup. Explicitly calling resize forces the map to redraw, which
mitigates the gray screen issue.
